### PR TITLE
Refactor: corrected routing and restructured MainLayout positioning

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,16 +1,15 @@
 import "./App.css";
+
 import { Routes, Route } from "react-router-dom";
+
 import All from "./pages/All";
 import Active from "./pages/Active";
 import Inactive from "./pages/Inactive";
-import MainPage from "./Components/layouts/MainPage";
 import NoMatch from "./pages/NoMatch";
 
 const App = () => {
   return (
     <div className="bg-slate-900 px-4 text-white py-8">
-      <MainPage />
-
       <Routes>
         <Route path="/" element={<All />} />
         <Route path="active-extensions" element={<Active />} />

--- a/src/pages/Active.jsx
+++ b/src/pages/Active.jsx
@@ -12,6 +12,7 @@ import { FaShapes } from "react-icons/fa";
 import { FaFaceSmile } from "react-icons/fa6";
 import { FaFlagCheckered } from "react-icons/fa6";
 import { FaMugHot } from "react-icons/fa6";
+import MainPage from "../Components/layouts/MainPage";
 
 const Active = () => {
   return (
@@ -25,7 +26,7 @@ const Active = () => {
           Theme2={<LuSunMoon />}
         />
       </div>
-
+      <MainPage />
       <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-2">
         <ExtensionCard
           firstIcon={<FaCloud />}

--- a/src/pages/All.jsx
+++ b/src/pages/All.jsx
@@ -17,6 +17,7 @@ import { FaFaceSmile } from "react-icons/fa6";
 import { FaFlagCheckered } from "react-icons/fa6";
 import { FaStapler } from "react-icons/fa6";
 import { FaMugHot } from "react-icons/fa6";
+import MainPage from "../Components/layouts/MainPage";
 
 const All = () => {
   return (
@@ -27,6 +28,7 @@ const All = () => {
         Theme1={<FaMoon />}
         Theme2={<LuSunMoon />}
       />
+      <MainPage />
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
         <ExtensionCard
           firstIcon={<FaCloud />}

--- a/src/pages/Inactive.jsx
+++ b/src/pages/Inactive.jsx
@@ -8,6 +8,7 @@ import { IoGrid } from "react-icons/io5";
 import { IoSettingsSharp } from "react-icons/io5";
 import { FaMoon } from "react-icons/fa6";
 import { LuSunMoon } from "react-icons/lu";
+import MainPage from "../Components/layouts/MainPage";
 
 const Inactive = () => {
   return (
@@ -21,6 +22,7 @@ const Inactive = () => {
           Theme2={<LuSunMoon />}
         />
       </div>
+      <MainPage />
       <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-2">
         <ExtensionCard
           firstIcon={<FaStaffSnake />}


### PR DESCRIPTION
- Moved MainLayout component from App.jsx into respective pages
- Adjusted layout so MainLayout now appears as the second element instead of the first
- Improved page structure and positioning to meet the intended design

Why:
Previously, MainLayout wrapped all pages from App.jsx, which caused it to render first across all pages. Moving it into individual pages allows more flexible placement and better structure.

How to test:
1. Pull the branch
2. Run npm start
3. Navigate to /, /active-extensions, and /inactive-extensions
4. Verify that MainLayout appears in the correct position on each page